### PR TITLE
Update init.angler.rc - fix qmud

### DIFF
--- a/init.angler.rc
+++ b/init.angler.rc
@@ -279,9 +279,11 @@ service thermal-engine /system/bin/thermal-engine
     group root radio
 
 # QMUX must be in multiple groups to support external process connections
+# change user from 'radio' to 'root' to stop logcat spam and allow qmi to set io_wake_lock/io_wake_unlock.  
+# see https://android.googlesource.com/device/lge/bullhead/+/95aa2b4e2d6c26ee1b37241bc22ec32a6382d3fb%5E!/#F0
 service qmuxd /system/bin/qmuxd
     class main
-    user radio
+    user root
     group radio audio bluetooth gps
 
 service perfd /system/bin/perfd


### PR DESCRIPTION
This change was applied a while ago to the 5X and never the 6P for some reason.  The 6P has the same problem described in googlesource link in my code comments. 

https://android.googlesource.com/device/lge/bullhead/+/95aa2b4e2d6c26ee1b37241bc22ec32a6382d3fb%5E!/#F0

so I think it's safe to assume that this small change got lost in the world of Google code and never was applied to the 6P as it should have been.

Trying to spread this small change around to the xda devs so qmuxd can function properly and we can stop seeing it's logcat error spam in our ROMs